### PR TITLE
index: remove duplicate versions

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -1586,9 +1586,6 @@
       </version>
     </reapack>
     <reapack name="X-Raym_Convert selected item notes to take name.lua" type="script">
-      <version name="1.1" author="X-Raym" time="2015-03-25T12:51:41Z">
-        <source main="true">https://github.com/X-Raym/REAPER-ReaScripts/raw/05876b1a4b12a54eadf98e1a05d7875071de7dde/Text%20Items%20and%20Item%20Notes/Conversion/X-Raym_Convert%20selected%20item%20notes%20to%20take%20name.lua</source>
-      </version>
       <version name="1.1" author="X-Raym" time="2016-05-23T22:29:48Z">
         <changelog><![CDATA[+ bug fix (if empty item was selected)]]></changelog>
         <source main="true">https://github.com/X-Raym/REAPER-ReaScripts/raw/664bb42a5a1cd6aaf741d58679b4363d3f06de67/Text%20Items%20and%20Item%20Notes/Conversion/X-Raym_Convert%20selected%20item%20notes%20to%20take%20name.lua</source>
@@ -1912,9 +1909,6 @@
       </version>
     </reapack>
     <reapack name="X-Raym_Delete font color markup from selected items notes.lua" type="script">
-      <version name="1.1" author="X-Raym" time="2015-03-07T15:01:01Z">
-        <source main="true">https://github.com/X-Raym/REAPER-ReaScripts/raw/fa81bae94b5d5760cde4b76eca42774381f470d3/Text%20Items%20and%20Item%20Notes/Formatting/X-Raym_Delete%20font%20color%20markup%20from%20selected%20items%20notes.lua</source>
-      </version>
       <version name="1.1" author="X-Raym" time="2015-12-24T16:57:47Z">
         <changelog><![CDATA[# Better Set Notes]]></changelog>
         <source main="true">https://github.com/X-Raym/REAPER-ReaScripts/raw/05876b1a4b12a54eadf98e1a05d7875071de7dde/Text%20Items%20and%20Item%20Notes/Formatting/X-Raym_Delete%20font%20color%20markup%20from%20selected%20items%20notes.lua</source>


### PR DESCRIPTION
Hi,

Since commit 20f4da48942236c9d4a60d7f2124602ae69b76fa (fix for versions starting with `v`), `Convert selected item notes to take name.lua` and `Delete font color markup from selected items notes.lua` had two versions 1.1 in the index.

The duplicates should not exist, and they are not cleaned up properly by ReaPack (resulting in a memory leak). I'm adding some checks against this and, starting with 1.1beta2, ReaPack will reject any duplicate versions.

This commit removes the older 1.1s.
