### PR TITLE
Support nil values when sorting tracks by name

### DIFF
--- a/Track Properties/X-Raym_Sort all tracks alphabetically.lua
+++ b/Track Properties/X-Raym_Sort all tracks alphabetically.lua
@@ -35,7 +35,11 @@
 							if a.name:match(p) and b.name:match(p) then
 								local a_num = tonumber(a.name:match(p))
 								local b_num = tonumber(b.name:match(p))
-								cond = a_num<b_num
+								if a_num ~= nil and b_num ~= nil then
+									cond = a_num<b_num
+								else
+									cond = false
+								end
 							end
 							return cond
 						end )


### PR DESCRIPTION
When attempting to sort track names in a project that was from an AA Translator export for some reason either `a_num` or `b_num` (or both) were `nil`.