### PR TITLE
Note duplication ReaScript name fixes

### DIFF
--- a/MIDI Editor/X-Raym_Duplicate selected notes as fifth.lua
+++ b/MIDI Editor/X-Raym_Duplicate selected notes as fifth.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name: Duplicate selected notes as fifth and octave triad
+ * ReaScript Name: Duplicate selected notes as fifth
  * Description: See title
  * Instructions: Run
  * Author: X-Raym

--- a/MIDI Editor/X-Raym_Duplicate selected notes as fourth.lua
+++ b/MIDI Editor/X-Raym_Duplicate selected notes as fourth.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name: Duplicate selected notes as fifth and octave triad
+ * ReaScript Name: Duplicate selected notes as fourth
  * Description: See title
  * Instructions: Run
  * Author: X-Raym


### PR DESCRIPTION
The ReaScript names of the note duplication actions were the same for all 3 actions, which made them hard to distinguish at times. This patch fixes these two names.