### PR TITLE
Add optional note pass-through

### DIFF
--- a/JSFX/MIDI/X-Raym_MIDI single note map.jsfx
+++ b/JSFX/MIDI/X-Raym_MIDI single note map.jsfx
@@ -1,8 +1,8 @@
 /**
  * JSFX Name: MIDI single note map
- * About: Quickly remap a MIDI note (with optional pass-through)
+ * About: Quickly remap a MIDI note
  * Screenshot: https://monosnap.com/image/HtvY0eslYZ72Hl6K0Nb8cf7psJPTJp.png
- * Author: X-Raym
+ * Author: X-Raym, Scrumpy Jack
  * Author URI: https://www.extremraym.com
  * Donation: http://www.extremraym.com/en/donation
  * Licence: GPL v3
@@ -12,20 +12,20 @@
 
 /**
  * Changelog:
- * v1.0 (2018-11-11)
-  + Initial Release
  * v1.1 (2025-11-11)
   + Add optional pass-through for the original note
+ * v1.0 (2018-11-11)
+  + Initial Release
  */
 
-desc:MIDI single note map + optional mirror
+desc:MIDI single note map
 
 slider1:0<0,16,1{Any,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16}>Input Channel
 
 slider10:note_in=36<0,127,1>Note IN
 slider11:note_out=36<0,127,1>Note OUT
 
-slider19:note_passthru=0<0,1,1{no,yes}>Pass-through Original Note
+slider21:note_passthru=0<0,1,1{no,yes}>Pass-through Original Note
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/JSFX/MIDI/X-Raym_MIDI single note map.jsfx
+++ b/JSFX/MIDI/X-Raym_MIDI single note map.jsfx
@@ -1,27 +1,31 @@
 /**
  * JSFX Name: MIDI single note map
- * About: Quickly remap a MIDI note
+ * About: Quickly remap a MIDI note (with optional pass-through)
  * Screenshot: https://monosnap.com/image/HtvY0eslYZ72Hl6K0Nb8cf7psJPTJp.png
  * Author: X-Raym
  * Author URI: https://www.extremraym.com
  * Donation: http://www.extremraym.com/en/donation
  * Licence: GPL v3
  * REAPER: 5.0
- * Version: 1.0
+ * Version: 1.1
  */
 
 /**
  * Changelog:
  * v1.0 (2018-11-11)
   + Initial Release
+ * v1.1 (2025-11-11)
+  + Add optional pass-through for the original note
  */
 
-desc:MIDI single note map
+desc:MIDI single note map + optional mirror
 
 slider1:0<0,16,1{Any,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16}>Input Channel
 
-slider10:36<0,127,1>Note IN
-slider11:36<0,127,1>Note OUT
+slider10:note_in=36<0,127,1>Note IN
+slider11:note_out=36<0,127,1>Note OUT
+
+slider19:note_passthru=0<0,1,1{no,yes}>Pass-through Original Note
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -55,11 +59,12 @@ while
       status == statNoteOn || status == statNoteOff || status == afterTouch ?
       (
 
-        // If note is in Makey Makey MIDI Range
-        note == slider10 ? (
-
-          note = slider( 11 ); // Get Note Out
-
+        // Does it match the note to remap?
+        note == note_in ? (
+          note_passthru == 1 ? ( // optional: pass on the original MIDI note
+            midisend(offset, msg1, note, vel);
+          );
+          note = note_out; // Map the new note to send out
         );
 
       );


### PR DESCRIPTION
Added an optional pass-through setting to send the original note alongside the mapped one (good for beefing up drum pads) .